### PR TITLE
eliminate cpu architecture constraint for nvcc

### DIFF
--- a/cuda/templates/BUILD.local_toolchain_nvcc
+++ b/cuda/templates/BUILD.local_toolchain_nvcc
@@ -35,11 +35,9 @@ toolchain(
     name = "nvcc-local-toolchain",
     exec_compatible_with = [
         "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
     ],
     target_compatible_with = [
         "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
     ],
     target_settings = [
         "@rules_cuda//cuda:is_enabled",


### PR DESCRIPTION
This PR simply removes the `@platforms//cpu:x86_64` constraint from the nvcc toolchain template. I'm not sure if this is the preferred way to achieve this, but CUDA on linux is compatible with aarch64 for both servers and embedded use cases. This enables builds with on these platforms as well.