### PR TITLE
add agx orin & hopper compute capabilities

### DIFF
--- a/cuda/private/providers.bzl
+++ b/cuda/private/providers.bzl
@@ -14,6 +14,8 @@ cuda_archs = [
     "75",
     "80",
     "86",
+    "87",
+    "90"
 ]
 
 Stage2ArchInfo = provider(


### PR DESCRIPTION
AGX Orin has compute capability 8.7, and Hopper has compute capability 9.0. Add both to providers to enable targeting these platforms.