### PR TITLE
Disable arch_native by default

### DIFF
--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -158,7 +158,7 @@ def _impl(ctx):
 
     arch_native_feature = feature(
         name = "arch_native",
-        enabled = nvcc_version_ge(ctx, 11, 6),
+        enabled = False,
         flag_sets = [
             flag_set(
                 actions = [


### PR DESCRIPTION
It is common to compile on machines that don't have a GPU installed e.g. RBE build nodes. Also setting default compilation to use the native arch is not as reproducible because it is dependent upon the hardware of the build node that the compiler is invoked on.

Turn off the arch_native feature by default to make the default configuration more reproducible.